### PR TITLE
dataservices: Don't pollute the tree

### DIFF
--- a/datatop/Android.mk
+++ b/datatop/Android.mk
@@ -1,2 +1,3 @@
+ifeq ($(call my-dir),$(call project-path-for,qcom-dataservices))
 include $(call all-subdir-makefiles)
-
+endif

--- a/rmnetctl/Android.mk
+++ b/rmnetctl/Android.mk
@@ -1,2 +1,3 @@
+ifeq ($(call my-dir),$(call project-path-for,qcom-dataservices))
 include $(call all-subdir-makefiles)
-
+endif


### PR DESCRIPTION
 * Nexus devices have a copy of this in their device repo already.
   Exclude it unless we're doing a QC-style build.

Change-Id: I2a4d3d9656be28b614e3ee59514b54801c833c3e

dataservices: You say BOARD, I say TARGET

 * Fix derp.

Change-Id: I038f4e9618b1ff9b128f73c9f15cf5b71c01f45c

Makefiles: Use project pathmap to determine build eligibility

Change-Id: Ie14dbc002bd06fdbfd85d77b8d0f892d286d889b